### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/arcpy_metadata/metadata_editor.py
+++ b/arcpy_metadata/metadata_editor.py
@@ -96,7 +96,7 @@ class MetadataEditor(object):
                     self.metadata_file = os.path.join(self.temp_folder, metadata_filename)
                     if os.path.exists(self.metadata_file):
                         os.remove(self.metadata_file)
-                    logwrite("Exporting metadata to temporary file %s" % self.metadata_file)
+                    logwrite("Exporting metadata to temporary file {0!s}".format(self.metadata_file))
                     arcpy.XSLTransform_conversion(self.dataset, xslt, self.metadata_file)
                 else:
                     raise TypeError("Datatype is not supported")
@@ -106,7 +106,7 @@ class MetadataEditor(object):
         # create these all after the parsing happens so that if they have any self initialization, they can correctly perform it
 
         for name in elements.keys():
-            setattr(self, "_%s" % name, None)
+            setattr(self, "_{0!s}".format(name), None)
 
             if elements[name]['type'] in ["string", "date", "integer", "float"]:
                 setattr(self, "_{}".format(name), MetadataItem(elements[name]['path'], name, self))
@@ -213,7 +213,7 @@ class MetadataEditor(object):
 
             elif elements[n]['type'] == "local":
                 if isinstance(v, MetadataLocals):
-                    self.__dict__["_%s" % n] = v
+                    self.__dict__["_{0!s}".format(n)] = v
                 else:
                     raise RuntimeWarning("Input value must be of type MetadataLocals")
 
@@ -232,7 +232,7 @@ class MetadataEditor(object):
                 # elif v is None:
                 #     self.__dict__["_%s" % n].value = []
                 if isinstance(v, MetadataContact):
-                    self.__dict__["_%s" % n] = v
+                    self.__dict__["_{0!s}".format(n)] = v
                 else:
                     raise RuntimeWarning("Input value must be a MetadataContact object")
 

--- a/arcpy_metadata/metadata_items.py
+++ b/arcpy_metadata/metadata_items.py
@@ -111,7 +111,7 @@ class MetadataLocal(MetadataParentItemConstructor):
     def __init__(self, parent, path, language, country):
 
         self.parent = parent
-        self.path = "%s[@language='%s'][@country='%s']" % (path, language, country)
+        self.path = "{0!s}[@language='{1!s}'][@country='{2!s}']".format(path, language, country)
 
         super(MetadataLocal, self).__init__(self.parent)
 
@@ -189,7 +189,7 @@ class MetadataContact(MetadataParentItemConstructor):
     # TODO: Define Role, Country and Online Resource list
     def __init__(self, path, name, parent=None, index=0):
         self.name = name
-        self.path = "%s[%i]" % (path, index)
+        self.path = "{0!s}[{1:d}]".format(path, index)
         super(MetadataContact, self).__init__(parent, contact_elements)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wri:arcpy_metadata?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wri:arcpy_metadata?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)